### PR TITLE
Fix build failed with RN 0.55.3

### DIFF
--- a/android/src/main/java/com/wednesdaynight/rn2c2p/RNMy2c2pSdkPackage.java
+++ b/android/src/main/java/com/wednesdaynight/rn2c2p/RNMy2c2pSdkPackage.java
@@ -15,12 +15,7 @@ public class RNMy2c2pSdkPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
       return Arrays.<NativeModule>asList(new RNMy2c2pSdkModule(reactContext));
     }
-
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
+    
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();


### PR DESCRIPTION
Due to breaking changes in https://github.com/facebook/react-native/releases/tag/v0.47.0 which "createJSModules" was removed.